### PR TITLE
handle ruby 3.x keyword arguments delegation

### DIFF
--- a/lib/polymorphic_integer_type/extensions.rb
+++ b/lib/polymorphic_integer_type/extensions.rb
@@ -87,7 +87,7 @@ module PolymorphicIntegerType
         end
 
         remove_type_and_establish_mapping(name, options, scope)
-        super(name, options.delete(:scope), options, &extension)
+        super(name, options.delete(:scope), **options, &extension)
       end
 
       def has_one(name, scope = nil, **options)
@@ -97,7 +97,7 @@ module PolymorphicIntegerType
         end
 
         remove_type_and_establish_mapping(name, options, scope)
-        super(name, options.delete(:scope), options)
+        super(name, options.delete(:scope), **options)
       end
 
 


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/